### PR TITLE
fix webpack warnings

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,9 @@ let config = dev.getDefaultWebpackConfig({
         '../build/default/validation': 'commonjs ../build/default/validation',
         '../build/Release/bufferutil': 'commonjs ../build/Release/bufferutil',
         '../build/default/bufferutil': 'commonjs ../build/default/bufferutil',
+        // Fix: Module not found
+        'applicationinsights-native-metrics': 'commonjs applicationinsights-native-metrics',
+        'diagnostic-channel-publishers': 'commonjs diagnostic-channel-publishers',
     },
 });
 


### PR DESCRIPTION
```
WARNING in ./node_modules/@vscode/extension-telemetry/lib/telemetryReporter.node.min.js 8:14890-14935
Module not found: Error: Can't resolve 'applicationinsights-native-metrics' in 'C:\Users\user\Work\vscode-azurespringcloud\node_modules\@vscode\extension-telemetry\lib'

WARNING in ./node_modules/applicationinsights/out/AutoCollection/NativePerformance.js 49:44-89
Module not found: Error: Can't resolve 'applicationinsights-native-metrics' in 'C:\Users\user\Work\vscode-azurespringcloud\node_modules\applicationinsights\out\AutoCollection'

WARNING in ./node_modules/diagnostic-channel-publishers/dist/src/azure-coretracing.pub.js 24:26-71
Module not found: Error: Can't resolve '@opentelemetry/tracing' in 'C:\Users\user\Work\vscode-azurespringcloud\node_modules\diagnostic-channel-publishers\dist\src'
```